### PR TITLE
Updated install instructions and dependencies

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,29 @@
-MIT License
+BSD 3-Clause License
 
-Copyright (c) 2018 Indiana University
+Copyright (c) 2018, Indiana University
+All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -19,18 +19,12 @@ src/sass/rivet-add-on-boilerplate.scss
 src/sass/components/_rivet-add-on-boilerplate.scss
 ```
 
-This can be done with the following commands on a unix based system
-
-```
-# TODO write this
-```
-
 ### 2. Include the CSS and JavaScript in your page
 After renaming the CSS and JavaScript files to reflect the name of your add-on, update the `href` and `src` attribute values on lines `10` and `20` in `src/_includes/layouts/base.njk` to point to your renamed files.
 
 ```html
-<link rel="stylesheet" href="dist/css/rivet-add-on-boilerplate.min.css">
-<script src="dist/js/rivet-add-on-boilerplate.min.js"></script>
+<link rel="stylesheet" href="dist/css/rivet-add-on-boilerplate.css">
+<script src="dist/js/rivet-add-on-boilerplate.js"></script>
 ```
 
 ### 3. Add the markup to your HTML
@@ -70,4 +64,5 @@ All files that are watched by default development task (`npm run start`) are com
 - [X] Add steps to build `dist` folder with compiled and minified versions of add-on `.js` and `.css` files
 - [X] Copy documentation from original boilerplate here: https://github.com/indiana-university/rivet-boilerplate
 - [ ] Add section to the docs about all the build steps included in `gulpfile.js`. For instance, how to build the `/dist` folder for the final version and minified code.
+- [ ] Add documentation about using values from `package.json` to create the banner (version, license, etc.) for all files in the `dist/` folder
 - [ ] Add default `CONTRIBUTING.md`, `ISSUE_TEMPLATE.md`, and `PULL_REQEST_TEMPLATE.md` to `.github` folder.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repo is meant to be cloned and used as a starting point for your Rivet add-
 Setting up the Rivet add-on boilerplate repo is a four-step process:
 
 ### 1. Clone this repo
-Clone this repo `https://github.iu.edu/UITS/rivet-bopilerplate` to the computer on which you'll be developing your add-on.
+Clone this repo `https://github.com/indiana-university/rivet-add-on-boilerplate.git` to the computer on which you'll be developing your add-on.
 
 Do a find-and-replace of the word "add-on-boilerplate" with the name of your add-on. A find-and-replace should be replaced on *file contents*, as well as for the filenames below
 
@@ -33,7 +33,7 @@ We've provided a Nunjucks include called `demo-html.njk` where you can put the m
 This is also a great place to add documentation, [accessibility notes](https://rivet.iu.edu/components/navigation/dropdown/#accessibility-notes), or [microcopy guidelines](https://rivet.iu.edu/content-guide/), as the `index.html` file will be built to the `docs` folder and can be published with GitHub Pages.
 
 ### 4. Write add-on documentation, accessibility notes, and microcopy guidelines
-We've proviede a template to use for your `README` file called `README.template.md`. To get started creating the README for your add-on follow these steps:
+We've provide a template to use for your `README` file called `README.template.md`. To get started creating the README for your add-on follow these steps:
 
 1. Delete this file
 2. Rename `README.template.md` to `README.md` (the same as the file you just deleted). This is where you'll put your documentation and any other important information about your add-on.
@@ -56,7 +56,7 @@ After you have Node installed, do the following:
 2. `npm install` to install all dependencies
 3. Run `npm run start` to start a development server and watch for changes to `.scss`, `.js`. `.md` files.
 
-This boilerplate uses [Eleventy](https://www.11ty.io/) to compile Markdown documentation to HTML. It also include Sass for CSS preprocessing and uses [Rollup](https://rollupjs.org/guide/en) to process modern JavaScript (ES6) into JavaScript that can saftely be used in the browser.
+This boilerplate uses [Eleventy](https://www.11ty.io/) to compile Markdown documentation to HTML. It also include Sass for CSS preprocessing and uses [Rollup](https://rollupjs.org/guide/en) to process modern JavaScript (ES6) into JavaScript that can safely be used in the browser.
 
 All files that are watched by default development task (`npm run start`) are compiled to and served from the `/docs` directory.
 

--- a/dist/css/rivet-add-on-boilerplate.css
+++ b/dist/css/rivet-add-on-boilerplate.css
@@ -1,6 +1,9 @@
-/*! rivet-add-on-boilerplate - @version v0.1.0-alpha
-© 2018, The Trustees of Indiana University
+/*!
+ * rivet-add-on-boilerplate - @version 0.1.0-alpha
+ * (c) 2018, The Trustees of Indiana University | MIT License
+ * https://github.com/indiana-university/rivet-add-on-boilerplate
  */
+
 /*! Rivet - @version v1.0.0 */
 .rvt-add-on-boilerplate {
   font-size: 1.625rem;

--- a/dist/css/rivet-add-on-boilerplate.css
+++ b/dist/css/rivet-add-on-boilerplate.css
@@ -1,10 +1,33 @@
-/*!
- * rivet-add-on-boilerplate - @version 0.1.0-alpha
- * (c) 2018, The Trustees of Indiana University | MIT License
- * https://github.com/indiana-university/rivet-add-on-boilerplate
- */
+/*! rivet-add-on-boilerplate - @version 0.1.0-alpha
 
-/*! Rivet - @version v1.0.0 */
+* Copyright (c) 2018 TheTrustees of Indiana University
+
+* Licensed under the BSD 3-Clause License.
+
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*   1.Redistributions of source code must retain the above copyright notice,
+*   this list of conditions and the following disclaimer.
+*   2.Redistributions in binary form must reproduce the above copyright notice,
+*   this list of conditions and the following disclaimer in the documentation
+*   and/or other materials provided with the distribution.
+*   3.Neither the name of the copyright holder nor the names of its
+*   contributors may be used to endorse or promote products derived from
+*   this software without specific prior written permission.
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*! rivet-uits - @version v1.1.0 */
 .rvt-add-on-boilerplate {
   font-size: 1.625rem;
   display: block;

--- a/dist/css/rivet-add-on-boilerplate.min.css
+++ b/dist/css/rivet-add-on-boilerplate.min.css
@@ -1,4 +1,7 @@
-/*! rivet-add-on-boilerplate - @version v0.1.0-alpha
-© 2018, The Trustees of Indiana University
+/*!
+ * rivet-add-on-boilerplate - @version 0.1.0-alpha
+ * (c) 2018, The Trustees of Indiana University | MIT License
+ * https://github.com/indiana-university/rivet-add-on-boilerplate
  */
+
 /*! Rivet - @version v1.0.0 */.rvt-add-on-boilerplate{font-size:1.625rem;display:block}

--- a/dist/css/rivet-add-on-boilerplate.min.css
+++ b/dist/css/rivet-add-on-boilerplate.min.css
@@ -1,7 +1,30 @@
-/*!
- * rivet-add-on-boilerplate - @version 0.1.0-alpha
- * (c) 2018, The Trustees of Indiana University | MIT License
- * https://github.com/indiana-university/rivet-add-on-boilerplate
- */
+/*! rivet-add-on-boilerplate - @version 0.1.0-alpha
 
-/*! Rivet - @version v1.0.0 */.rvt-add-on-boilerplate{font-size:1.625rem;display:block}
+* Copyright (c) 2018 TheTrustees of Indiana University
+
+* Licensed under the BSD 3-Clause License.
+
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*   1.Redistributions of source code must retain the above copyright notice,
+*   this list of conditions and the following disclaimer.
+*   2.Redistributions in binary form must reproduce the above copyright notice,
+*   this list of conditions and the following disclaimer in the documentation
+*   and/or other materials provided with the distribution.
+*   3.Neither the name of the copyright holder nor the names of its
+*   contributors may be used to endorse or promote products derived from
+*   this software without specific prior written permission.
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*! rivet-uits - @version v1.1.0 */.rvt-add-on-boilerplate{font-size:1.625rem;display:block}

--- a/dist/js/rivet-add-on-boilerplate.js
+++ b/dist/js/rivet-add-on-boilerplate.js
@@ -1,8 +1,31 @@
-/*!
- * rivet-add-on-boilerplate - @version 0.1.0-alpha
- * (c) 2018, The Trustees of Indiana University | MIT License
- * https://github.com/indiana-university/rivet-add-on-boilerplate
- */
+/*! rivet-add-on-boilerplate - @version 0.1.0-alpha
+
+* Copyright (c) 2018 TheTrustees of Indiana University
+
+* Licensed under the BSD 3-Clause License.
+
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*   1.Redistributions of source code must retain the above copyright notice,
+*   this list of conditions and the following disclaimer.
+*   2.Redistributions in binary form must reproduce the above copyright notice,
+*   this list of conditions and the following disclaimer in the documentation
+*   and/or other materials provided with the distribution.
+*   3.Neither the name of the copyright holder nor the names of its
+*   contributors may be used to endorse or promote products derived from
+*   this software without specific prior written permission.
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
 
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :

--- a/dist/js/rivet-add-on-boilerplate.js
+++ b/dist/js/rivet-add-on-boilerplate.js
@@ -1,6 +1,9 @@
-/*! rivet-add-on-boilerplate - @version v0.1.0-alpha
-© 2018, The Trustees of Indiana University
+/*!
+ * rivet-add-on-boilerplate - @version 0.1.0-alpha
+ * (c) 2018, The Trustees of Indiana University | MIT License
+ * https://github.com/indiana-university/rivet-add-on-boilerplate
  */
+
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
   typeof define === 'function' && define.amd ? define(factory) :

--- a/dist/js/rivet-add-on-boilerplate.min.js
+++ b/dist/js/rivet-add-on-boilerplate.min.js
@@ -1,4 +1,7 @@
-/*! rivet-add-on-boilerplate - @version v0.1.0-alpha
-© 2018, The Trustees of Indiana University
+/*!
+ * rivet-add-on-boilerplate - @version 0.1.0-alpha
+ * (c) 2018, The Trustees of Indiana University | MIT License
+ * https://github.com/indiana-university/rivet-add-on-boilerplate
  */
+
 !function(e,n){"object"==typeof exports&&"undefined"!=typeof module?module.exports=n():"function"==typeof define&&define.amd?define(n):e.MyComponent=n()}(this,function(){"use strict";return{init:function(){console.log("Rivet Add-on Boilerplate!")}}});

--- a/dist/js/rivet-add-on-boilerplate.min.js
+++ b/dist/js/rivet-add-on-boilerplate.min.js
@@ -1,7 +1,30 @@
-/*!
- * rivet-add-on-boilerplate - @version 0.1.0-alpha
- * (c) 2018, The Trustees of Indiana University | MIT License
- * https://github.com/indiana-university/rivet-add-on-boilerplate
- */
+/*! rivet-add-on-boilerplate - @version 0.1.0-alpha
+
+* Copyright (c) 2018 TheTrustees of Indiana University
+
+* Licensed under the BSD 3-Clause License.
+
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*   1.Redistributions of source code must retain the above copyright notice,
+*   this list of conditions and the following disclaimer.
+*   2.Redistributions in binary form must reproduce the above copyright notice,
+*   this list of conditions and the following disclaimer in the documentation
+*   and/or other materials provided with the distribution.
+*   3.Neither the name of the copyright holder nor the names of its
+*   contributors may be used to endorse or promote products derived from
+*   this software without specific prior written permission.
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
 
 !function(e,n){"object"==typeof exports&&"undefined"!=typeof module?module.exports=n():"function"==typeof define&&define.amd?define(n):e.MyComponent=n()}(this,function(){"use strict";return{init:function(){console.log("Rivet Add-on Boilerplate!")}}});

--- a/docs/css/rivet-add-on-boilerplate.css
+++ b/docs/css/rivet-add-on-boilerplate.css
@@ -1,4 +1,4 @@
-/*! Rivet - @version v1.0.0 */
+/*! rivet-uits - @version v1.1.0 */
 .rvt-add-on-boilerplate {
   font-size: 1.625rem;
   display: block;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,17 +19,13 @@ const package = require('./package.json');
 // Get the current year for copyright in the banner
 const currentYear = new Date().getFullYear();
 
-// Create the string for the verion number banner.
-const banner =
-  '/*! ' +
-  package.name +
-  ' - @version v' +
-  package.version +
-  '\n' +
-  '© ' + currentYear +', The Trustees of Indiana University' +
-  '\n' +
-  ' */' +
-  '\n';
+const banner = `/*!
+ * ${ package.name } - @version ${ package.version }
+ * (c) ${ currentYear }, The Trustees of Indiana University | ${ package.license } License
+ * ${ package.repository.url }
+ */
+
+`;
 
 // Development server
 gulp.task('serve', function () {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,11 +19,35 @@ const package = require('./package.json');
 // Get the current year for copyright in the banner
 const currentYear = new Date().getFullYear();
 
-const banner = `/*!
- * ${ package.name } - @version ${ package.version }
- * (c) ${ currentYear }, The Trustees of Indiana University | ${ package.license } License
- * ${ package.repository.url }
- */
+// Create the string for the verion number banner.
+const banner = `/*! ${package.name} - @version ${package.version}
+
+* Copyright (c) ${currentYear} TheTrustees of Indiana University
+
+* Licensed under the BSD 3-Clause License.
+
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*   1.Redistributions of source code must retain the above copyright notice,
+*   this list of conditions and the following disclaimer.
+*   2.Redistributions in binary form must reproduce the above copyright notice,
+*   this list of conditions and the following disclaimer in the documentation
+*   and/or other materials provided with the distribution.
+*   3.Neither the name of the copyright holder nor the names of its
+*   contributors may be used to endorse or promote products derived from
+*   this software without specific prior written permission.
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
 
 `;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rivet-add-on-boilerplate",
-  "version": "0.1.0-alpha",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9474,19 +9474,10 @@
         "glob": "^7.0.5"
       }
     },
-    "rivet-collapsible": {
-      "version": "0.1.0-alpha",
-      "resolved": "https://registry.npmjs.org/rivet-collapsible/-/rivet-collapsible-0.1.0-alpha.tgz",
-      "integrity": "sha512-MXTw2m7czSSGLfi49WEgqVmykNWHlK7PQSYc00GbtxZ+Yy9QvugGtypgpljSGDJDSdiLEsdCuTG6bkioe+y/Bg==",
-      "dev": true,
-      "requires": {
-        "rivet-uits": "^1.0.0"
-      }
-    },
     "rivet-uits": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rivet-uits/-/rivet-uits-1.0.0.tgz",
-      "integrity": "sha512-OCw17kcjIxGvDQYZxQTddNjab8pwMNH8h3Pqhd9ywx/1BstykVmtnIPY+HhEUGRjxxq/Z4F/s31yOPpWd9N60A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rivet-uits/-/rivet-uits-1.1.0.tgz",
+      "integrity": "sha512-FGoiWbwvKlq6s+jrfK2pNnuSTPdUuAaNyJskl8TqAYRcDAp2975mSjueVqS9r3fqd0DuqJt5tDfMyOV3m+fYTg==",
       "dev": true
     },
     "rollup": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivet-add-on-boilerplate",
-  "version": "0.1.0-alpha",
+  "version": "0.1.1",
   "description": "Add the description of your component here",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "main": "dist/js/rivet-add-on-boilerplate.js",
   "scripts": {
-    "postinstall": "gulp eleventy && gulp sass && gulp js",
     "start": "gulp",
     "build": "gulp release"
   },

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "gulp-uglify": "^3.0.0",
     "gulp-util": "^3.0.8",
     "pump": "^3.0.0",
-    "rivet-collapsible": "0.1.0-alpha",
-    "rivet-uits": "^1.0.0",
+    "rivet-uits": "^1.1.0",
     "rollup": "^0.60.4",
     "rollup-plugin-babel": "^3.0.4",
     "run-sequence": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "gulp release"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "@11ty/eleventy": "^0.3.5",
     "autoprefixer": "^8.6.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "gulp release"
   },
   "author": "",
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "devDependencies": {
     "@11ty/eleventy": "^0.3.5",
     "autoprefixer": "^8.6.3",


### PR DESCRIPTION
This PR updates the install and usage instructions and the Rivet version.

- Updated clone url in README
- Updated to rivet 1.1.0
- Updated license
- Removed `postinstall` command